### PR TITLE
Remove `uses-sdk` from plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,9 +38,6 @@
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     </config-file>
-    <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
-    </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <service


### PR DESCRIPTION
This fixes a `MultipleUsesSdk` lint error that breaks release builds.

```
Error: There should only be a single <uses-sdk> element in the manifest: merge these together [MultipleUsesSdk]
    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Recent Cordova versions generate a `<uses-sdk>` element with the min SDK set to 14 and the target SDK set to 22.