### PR TITLE
Update plugin.xml to add coarse location

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,9 @@
       <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest">
+      <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    </config-file>
+    <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest">


### PR DESCRIPTION
Add permission for ACCESS_COARSE_LOCATION to fix permission denied errors on Android 6. On Android 6 the scan never finishes and events for device found are never received within the plugin unless additional permissions are enabled.